### PR TITLE
⚡ Bolt: Batch DOM insertions in listConnections

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-21 - DOM Append in Loop Anti-pattern
+**Learning:** Found a DOM manipulation bottleneck in `public/jutty.js` where connections were appended to the DOM one by one inside a loop. This is a common anti-pattern that causes multiple reflows/repaints.
+**Action:** Always batch DOM updates by building an HTML string or DocumentFragment first, then appending it once to the DOM.

--- a/public/jutty.js
+++ b/public/jutty.js
@@ -150,13 +150,15 @@ $(document).ready(function () {
 
     function listConnections() {
         var names = Object.keys(savedConnections).sort();
-        $connections.html('');
+        var html = '';
         names.forEach(function (name) {
-            $connections.append('<a class="list-group-item load" href="#" data-target="' + name + '">' + name +
+            html += '<a class="list-group-item load" href="#" data-target="' + name + '">' + name +
                 '<button class="btn btn-xs btn-danger delete" data-name="' + name + '">' +
                 '<span class="glyphicon glyphicon-trash" aria-hidden="true"></span>' +
-                '</button></a>');
+                '</button></a>';
         });
+        // ⚡ Bolt: Batch DOM insertion to prevent multiple reflows/repaints inside the loop
+        $connections.html(html);
         $('a.load').click(function (e) {
             e.stopPropagation();
             setVals(savedConnections[$(this).data('target')]);


### PR DESCRIPTION
💡 What: Changed `$connections.append(...)` inside a loop to building an HTML string and calling `$connections.html(html)` once.
🎯 Why: Appending elements to the DOM one by one inside a loop causes O(N) reflows and repaints, which is a performance bottleneck.
📊 Impact: Reduces DOM manipulation cost from O(N) to O(1), improving rendering performance of the saved connections list.
🔬 Measurement: Verify by loading the page with multiple saved connections and observing smoother rendering.

---
*PR created automatically by Jules for task [15101746503769441832](https://jules.google.com/task/15101746503769441832) started by @mbarbine*