### PR TITLE
🎨 Palette: Improve connection form accessibility and UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility on dynamically generated list items
 **Learning:** In legacy javascript apps where DOM elements are created dynamically from strings (like in `jutty.js`), accessibility attributes like `aria-label` and `title` are often missed on icon-only action buttons.
 **Action:** Always scan string concatenation blocks that generate HTML buttons in legacy apps to ensure they include proper `aria-label` and `title` attributes, especially if they only contain an icon (e.g. `glyphicon`).
+## 2024-05-24 - Accessibility on Bootstrap 3 Input Groups
+**Learning:** Older Bootstrap 3 layouts often use `input-group-addon` spans instead of native `<label>` elements for form inputs, which causes screen readers to miss the input's purpose.
+**Action:** When working with legacy Bootstrap forms, always link the `input` to its `input-group-addon` using `aria-describedby` (or `aria-labelledby`) to ensure the field has a programmatic name/description.

--- a/public/index.html
+++ b/public/index.html
@@ -83,7 +83,7 @@
                         <div class="row">
                             <div class="col-lg-12 col-md-12 col-xs-12">
 
-                                <div class="btn-group" data-toggle="buttons">
+                                <div class="btn-group" data-toggle="buttons" aria-label="Connection Protocol">
                                     <label class="btn btn-primary active">
                                         <input type="radio" name="options" id="ssh" checked> SSH
                                     </label>
@@ -99,14 +99,14 @@
 
                             <div class="col-lg-8 col-md-8 col-xs-8">
                                 <div class="input-group">
-                                    <span class="input-group-addon">Host</span>
-                                    <input id="host" type="text" class="form-control">
+                                    <span class="input-group-addon" id="addon-host">Host</span>
+                                    <input id="host" type="text" class="form-control" aria-describedby="addon-host" placeholder="e.g. 192.168.1.10">
                                 </div>
                             </div>
                             <div class="col-lg-4 col-md-4 col-xs-4">
                                 <div class="input-group">
-                                    <span class="input-group-addon">Port</span>
-                                    <input type="number" id="port" class="form-control">
+                                    <span class="input-group-addon" id="addon-port">Port</span>
+                                    <input type="number" id="port" class="form-control" aria-describedby="addon-port" placeholder="22">
                                 </div>
                             </div>
                         </div>
@@ -114,8 +114,8 @@
                         <div class="ssh row">
                             <div class="col-lg-12 col-md-12 col-xs-12">
                                 <div class="input-group">
-                                    <span class="input-group-addon">User</span>
-                                    <input type="text" class="form-control" id="user">
+                                    <span class="input-group-addon" id="addon-user">User</span>
+                                    <input type="text" class="form-control" id="user" aria-describedby="addon-user" placeholder="e.g. root">
                                 </div>
                             </div>
                         </div>
@@ -142,8 +142,8 @@
 
                             <div class="col-lg-9 col-md-9 col-xs-9">
                                 <div class="input-group">
-                                    <span class="input-group-addon">Save as...</span>
-                                    <input id="name" type="text" class="form-control">
+                                    <span class="input-group-addon" id="addon-name">Save as...</span>
+                                    <input id="name" type="text" class="form-control" aria-describedby="addon-name" placeholder="Connection name">
                                     <span class="input-group-btn">
                     <button class="btn btn-primary" type="button" id="save">
                         <span class="glyphicon glyphicon-save-file" aria-hidden="true"></span> Save


### PR DESCRIPTION
💡 What: Added helpful placeholder text and ARIA attributes to connection form inputs.
🎯 Why: To make the interface more intuitive by showing expected input formats, and to improve screen reader accessibility for form fields that lack native `<label>` elements.
📸 Before/After: Screenshots were taken in headless chromium confirming placeholders display correctly.
♿ Accessibility:
- Inputs are now programmatically linked to their `input-group-addon` text using `aria-describedby`.
- The connection protocol button group (SSH/Telnet) now has an `aria-label="Connection Protocol"`.

---
*PR created automatically by Jules for task [16286736759781088324](https://jules.google.com/task/16286736759781088324) started by @mbarbine*