### PR TITLE
🎨 Palette: Fix list group HTML validity and add empty state for connections

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-24 - Accessibility on Bootstrap 3 Input Groups
 **Learning:** Older Bootstrap 3 layouts often use `input-group-addon` spans instead of native `<label>` elements for form inputs, which causes screen readers to miss the input's purpose.
 **Action:** When working with legacy Bootstrap forms, always link the `input` to its `input-group-addon` using `aria-describedby` (or `aria-labelledby`) to ensure the field has a programmatic name/description.
+
+## 2024-05-24 - Valid HTML with Bootstrap 3 list groups
+**Learning:** If a Bootstrap 3 list group container dynamically generates elements, using a `<ul>` tag and filling it with `<a>` anchor tags creates invalid HTML (anchors cannot be direct children of unordered lists). This breaks screen reader expectations.
+**Action:** Use `<div class="list-group">` instead of `<ul class="list-group">` for list groups containing anchors, and ensure empty states are presented so users don't encounter completely empty elements.

--- a/public/index.html
+++ b/public/index.html
@@ -164,9 +164,9 @@
                         <h3 class="panel-title">Saved Connections</h3>
                     </div>
                     <div class="panel-body">
-                        <ul id="connections" class="list-group">
+                        <div id="connections" class="list-group">
 
-                        </ul>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/public/jutty.js
+++ b/public/jutty.js
@@ -151,12 +151,16 @@ $(document).ready(function () {
     function listConnections() {
         var names = Object.keys(savedConnections).sort();
         var html = '';
-        names.forEach(function (name) {
-            html += '<a class="list-group-item load" href="#" data-target="' + name + '">' + name +
-                '<button class="btn btn-xs btn-danger delete" data-name="' + name + '" aria-label="Delete ' + name + ' connection" title="Delete ' + name + ' connection">' +
-                '<span class="glyphicon glyphicon-trash" aria-hidden="true"></span>' +
-                '</button></a>';
-        });
+        if (names.length === 0) {
+            html = '<div class="list-group-item text-muted">No saved connections yet. Fill out the options and click Save.</div>';
+        } else {
+            names.forEach(function (name) {
+                html += '<a class="list-group-item load" href="#" data-target="' + name + '">' + name +
+                    '<button class="btn btn-xs btn-danger delete" data-name="' + name + '" aria-label="Delete ' + name + ' connection" title="Delete ' + name + ' connection">' +
+                    '<span class="glyphicon glyphicon-trash" aria-hidden="true"></span>' +
+                    '</button></a>';
+            });
+        }
         // ⚡ Bolt: Batch DOM insertion to prevent multiple reflows/repaints inside the loop
         // 💡 What: Replaced individual `$connections.append()` calls inside the loop with string concatenation, then appending the final string once using `.html()`.
         // 🎯 Why: Repeated DOM manipulations inside a loop cause multiple expensive reflows and repaints, degrading rendering performance.


### PR DESCRIPTION
💡 **What:** 
1. Fixed invalid HTML structure where `<a>` tags were dynamically injected directly into a `<ul>` element by changing the list group container in `public/index.html` to a `<div>`.
2. Added a helpful empty state message to the "Saved Connections" panel when no connections exist.

🎯 **Why:** 
1. Having `<a>` elements as direct children of a `<ul>` creates invalid HTML and disrupts screen reader expectations. Using a `<div class="list-group">` is the correct Bootstrap 3 approach for linked items.
2. Presenting a completely blank panel when there are no saved connections provides poor UX. The empty state gives users clear guidance on what to do.

📸 **Before/After:**
*(Added visually verified empty state with clear instructions instead of a blank panel)*

♿ **Accessibility:**
Ensured the DOM structure correctly uses a `<div>` for a list group composed of anchor tags, improving compliance and screen reader parsing.

---
*PR created automatically by Jules for task [17700226504859174972](https://jules.google.com/task/17700226504859174972) started by @mbarbine*