### PR TITLE
🎨 Palette: UX improvements for keyboard navigation and destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-03 - Keyboard Navigation and Destructive Action UX
+**Learning:** Users naturally expect form-like behavior (pressing Enter to submit) within input groups, even if those inputs aren't formally enclosed in a `<form>` tag. Additionally, allowing immediate deletion without confirmation in custom UI lists can lead to easy accidental data loss.
+**Action:** When creating grouped inputs or login/connection panels, always bind `Enter` key presses to the primary action (e.g., submit/start). For any destructive actions like deleting saved items, always include at least a native `confirm()` dialog to provide a safety net for users.

--- a/public/jutty.js
+++ b/public/jutty.js
@@ -181,9 +181,12 @@ $(document).ready(function () {
     });
     $connections.on('click', 'button.delete', function (e) {
         e.stopPropagation();
-        delete savedConnections[$(this).data('name')];
-        store.set('connections', savedConnections);
-        listConnections();
+        var name = $(this).data('name');
+        if (confirm('Are you sure you want to delete the saved connection "' + name + '"?')) {
+            delete savedConnections[name];
+            store.set('connections', savedConnections);
+            listConnections();
+        }
         return false;
     });
 
@@ -262,9 +265,20 @@ $(document).ready(function () {
         }
     }
 
-    $name.keyup(checkButtons);
-    $host.keyup(checkButtons);
-    $user.keyup(checkButtons);
+    $name.keyup(function(e) {
+        checkButtons();
+        if (e.which === 13 && !$save.is(':disabled')) $save.click();
+    });
+
+    function triggerStartOnEnter(e) {
+        checkButtons();
+        if (e.which === 13 && !$start.is(':disabled')) start();
+    }
+
+    $host.keyup(triggerStartOnEnter);
+    $user.keyup(triggerStartOnEnter);
+    $port.keyup(triggerStartOnEnter);
+
     $ssh.change(checkButtons);
     $telnet.change(checkButtons);
 


### PR DESCRIPTION
## 🎨 Palette: Keyboard Navigation and Destructive Action UX Improvements

### 💡 What:
1.  **Keyboard Navigation:** Bound the `Enter` key on `#host`, `#port`, `#user` inputs to trigger the `start()` function (connect), and on the `#name` input to trigger the `save` function.
2.  **Destructive Action Confirmation:** Added a native `confirm()` dialog when a user clicks the delete button on a saved connection.
3.  **Journaling:** Documented the rationale for these UX improvements in `.jules/palette.md`.

### 🎯 Why:
-   **Keyboard Intuitiveness:** Users naturally expect to submit data by pressing `Enter` when focusing on input fields. This makes connection and saving actions significantly faster and more accessible for keyboard users without having to explicitly click buttons.
-   **Accidental Data Loss Prevention:** Deleting a saved connection is a destructive action that shouldn't happen instantaneously without a safety net. The confirm dialog ensures users actually intend to remove the item.

### ♿ Accessibility:
-   Improved overall keyboard accessibility and user confidence.

---
*PR created automatically by Jules for task [10911445860519727298](https://jules.google.com/task/10911445860519727298) started by @mbarbine*