### PR TITLE
🎨 Palette: Connection Form Micro-UX Enhancements

### DIFF
--- a/public/jutty.js
+++ b/public/jutty.js
@@ -30,6 +30,10 @@ $(document).ready(function () {
     var savedConnections = store.get('connections') || {};
     listConnections();
 
+    // Auto-focus Host field on load for better UX
+    setTimeout(function() {
+        $host.focus();
+    }, 100);
 
     function Jutty(argv) {
         this.argv_ = argv;
@@ -114,6 +118,9 @@ $(document).ready(function () {
         $back.hide();
         $settings.show();
         $terminal.hide();
+        // Restore document title
+        document.title = 'PH3AR Terminal';
+        $host.focus();
     });
 
     function getVals() {
@@ -193,13 +200,29 @@ $(document).ready(function () {
     $start.click(start);
 
     function start() {
+        if ($start.is(':disabled') || $start.data('connecting')) return;
+
         var vals = getVals();
+
+        // Set loading state
+        var originalHtml = $start.html();
+        $start.data('connecting', true).prop('disabled', true);
+        $start.html('<span class="glyphicon glyphicon-hourglass" aria-hidden="true"></span> Connecting...');
+
         htermInit(function () {
             vals.col = term.screenSize.width;
             vals.row = term.screenSize.height;
             socket.emit('start', vals);
             $settings.hide();
             $terminal.show().focus();
+
+            // Dynamic tab title
+            var connName = vals.user ? vals.user + '@' + vals.host : vals.host;
+            document.title = connName + ' - PH3AR Terminal';
+
+            // Restore button state
+            $start.data('connecting', false).prop('disabled', false);
+            $start.html(originalHtml);
         });
     }
 
@@ -209,6 +232,19 @@ $(document).ready(function () {
         store.set('connections', savedConnections);
 
         listConnections();
+
+        // Show visual feedback on save
+        var $btn = $(this);
+        var originalHtml = $btn.html();
+
+        $btn.removeClass('btn-primary').addClass('btn-success')
+            .html('<span class="glyphicon glyphicon-ok" aria-hidden="true"></span> Saved!')
+            .prop('disabled', true);
+
+        setTimeout(function() {
+            $btn.removeClass('btn-success').addClass('btn-primary').html(originalHtml).prop('disabled', false);
+            checkButtons(); // Re-evaluate disabled state
+        }, 1500);
     });
 
 
@@ -237,6 +273,7 @@ $(document).ready(function () {
     });
 
     function checkButtons() {
+        if ($start.data('connecting')) return; // Don't override loading state
         var obj = getVals();
         if (obj.type === 'ssh') {
             if (obj.host && obj.user) {


### PR DESCRIPTION
🎨 **Palette: Micro-UX Enhancements**

💡 **What:** 
Added a set of micro-UX enhancements to the connection form in `jutty.js`:
1.  **Auto-focus:** The "Host" input field automatically focuses when the page loads.
2.  **Loading State:** The "Connect" button now enters a disabled, "Connecting..." state while `htermInit` is initializing.
3.  **Visual Feedback:** The "Save" button briefly changes to a "Saved!" success state upon clicking, providing immediate visual confirmation.
4.  **Dynamic Tab Title:** The browser tab (`document.title`) updates to reflect the active connection (e.g., `user@host - PH3AR Terminal`) when a terminal session starts, and reverts when returning to the settings page.

🎯 **Why:** 
- The auto-focus reduces the need for mouse interaction, improving keyboard workflow right from the start.
- The loading state on the connect button prevents accidental double-clicks and provides immediate feedback during asynchronous initialization.
- The success feedback on the save button solves the issue of users wondering if their click actually registered.
- The dynamic tab title is a massive quality-of-life improvement for power users who keep multiple terminal sessions open across different browser tabs, allowing them to easily identify which tab belongs to which server.

📸 **Before/After:** 
A verification screenshot has been generated and validated to show the temporary "Saved!" state working correctly.

♿ **Accessibility:** 
Keyboard navigation is slightly improved by the initial auto-focus. The button disabled states prevent invalid interactions while maintaining clear, readable text alternatives.

---
*PR created automatically by Jules for task [17751673577950289674](https://jules.google.com/task/17751673577950289674) started by @mbarbine*