### PR TITLE
⚡ Bolt: Optimize rate limiting for static assets

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-21 - Event Binding Inside Loops Anti-pattern
 **Learning:** Found a memory leak and performance bottleneck in `public/jutty.js` where event listeners were bound to individual dynamically created elements inside a loop (`$('a.load').click(...)` inside `listConnections()`). Every time the list re-rendered, new listeners were attached, leading to un-garbage-collected closures and O(N) event binding complexity.
 **Action:** Use event delegation on a static parent container (e.g., `$connections.on('click', 'a.load', ...)`) outside the render function. This reduces event binding to O(1) and prevents memory leaks from accumulating closures on dynamic elements.
+
+## 2026-03-21 - Rate Limiting Static Assets Anti-pattern
+**Learning:** Found a performance bottleneck where `express-rate-limit` was applied globally to the `express.static` route. This meant every request for CSS, JS, and image assets invoked the rate limiter, wasting CPU/memory resources and rapidly depleting the user's limit.
+**Action:** Only apply rate limiters to main entry points (e.g., `app.get('/')` and `app.post('/')`) or API routes, and explicitly bypass rate limiting for static assets.

--- a/app.js
+++ b/app.js
@@ -27,12 +27,17 @@ app.use(bodyParser.urlencoded({
     extended: true
 }));
 
+app.get('/', limiter, function(req, res) {
+    res.sendFile(__dirname + '/public/index.html');
+});
+
 app.post('/', limiter, function(req, res) {
     res.sendFile(__dirname + '/public/index.html');
 });
 
 // Added maxAge for performance optimization (caching static files)
-app.use('/', limiter, express.static(path.join(__dirname, 'public/'), { maxAge: '1d' }));
+// ⚡ Bolt Optimization: Rate limiting is bypassed for static assets to improve performance and save server resources
+app.use('/', express.static(path.join(__dirname, 'public/'), { maxAge: '1d' }));
 
 function setupSocketIo(httpserv) {
     var io = server(httpserv, {path: '/socket.io'});


### PR DESCRIPTION
- 💡 What: Bypassed rate limiting for all static file requests via `express.static`, and added explicit rate limiting to the `GET /` and `POST /` entry routes instead.
- 🎯 Why: `express-rate-limit` was applied globally to the static file server route. This meant every single CSS, JS, and image request unnecessarily triggered the rate limit logic, wasting memory/CPU and rapidly exhausting the user's connection quota.
- 📊 Impact: Eliminates rate limit overhead for all static assets. Drops rate limiter invocations from ~10 per initial page load to exactly 1.
- 🔬 Measurement: Observe lower CPU/Memory usage under load and verify `express-rate-limit` headers/logs no longer appear for static assets like `/jutty.js`. Rate limits remain enforced on `/`.

---
*PR created automatically by Jules for task [14757991404900636755](https://jules.google.com/task/14757991404900636755) started by @mbarbine*