### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection bypass and DoS in socket connection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Command/Argument Injection via unsanitized `data.host` and `data.port` parameters in `socket.on('start')` which were directly passed to `pty.spawn`. An attacker could inject arguments starting with `-` like `-oProxyCommand`.
 **Learning:** Even though `pty.spawn` doesn't execute a shell directly, passing completely arbitrary arguments starting with hyphens can invoke dangerous features of the underlying program (e.g. telnet).
 **Prevention:** Always sanitize and validate socket inputs using strict regex (e.g., ensuring hostnames start with alphanumeric characters `^[a-zA-Z0-9]`) and explicitly parsing/bounding numbers before passing them to OS-level spawn commands.
+
+## 2024-04-10 - [Duplicate terminal event listeners and unsanitized parameters causing command injection bypass]
+**Vulnerability:** Double event listener registration for `term.on('data')` and `term.on('exit')` that was located outside `socket.on('start')`, combined with `safeHost` allowing leading hyphens, which could allow bypassing the regex check and injecting options to the telnet command spawned via `node-pty`.
+**Learning:** `term` is declared outside of `socket.on('start')` but double registered outside of it while `term.pid` accessing caused crashes. By only having the listener inside `start`, and also ensuring `safeHost` doesn't begin with a hyphen.
+**Prevention:** Remove duplicated code outside closures that depends on variables defined inside them, and add explicit prefix checks for arguments passed to `node-pty`.

--- a/app.js
+++ b/app.js
@@ -66,6 +66,13 @@ function setupSocketIo(httpserv) {
             var safeHost = hostStr.replace(/[^a-zA-Z0-9\.\-]/g, '');
             var safePort = portNum;
 
+            // Prevent command injection starting with a dash (-)
+            if (safeHost.startsWith('-')) {
+                log.error('Host cannot start with a hyphen');
+                socket.emit('end');
+                return;
+            }
+
             params = [safeHost, safePort.toString()];
 
             log.info(type, params.join(' '));
@@ -91,16 +98,6 @@ function setupSocketIo(httpserv) {
             });
         });
 
-        log.info(term.pid, 'spawned');
-        term.on('data', function(data) {
-            socket.emit('output', data);
-        });
-        term.on('exit', function (code) {
-            log.info(term.pid, 'ended');
-            socket.emit('end');
-            term.kill();
-            term = null;
-        });
 
         socket.on('resize', function (data) {
             term && term.resize(parseInt(data.col, 10) || 80, parseInt(data.row, 10) || 24);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command/Argument Injection via unsanitized `data.host` variable allowing options (like `-oProxyCommand`) into `pty.spawn`, and a Denial of Service (DoS) bug via event listeners placed outside the setup closure, attempting to read `term.pid` before it's assigned.
🎯 Impact: Attackers could crash the application by simply connecting and waiting without emitting `start`, and could potentially run arbitrary code via malicious argument injection on `hostStr`.
🔧 Fix: Removed the duplicate outer event listeners for `term`. Added a strict check to abort if `safeHost.startsWith('-')`.
✅ Verification: Ran `pnpm exec mocha "test/app.test.js" --exit` with all tests passing. Ensured code compiles without syntax errors and documented findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15393588561573510109](https://jules.google.com/task/15393588561573510109) started by @mbarbine*