### PR TITLE
🎨 Palette: Add immediate visual feedback to Save connection button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,7 @@
 ## 2024-05-24 - Enter Key Support for Non-Native Forms
 **Learning:** Legacy jQuery apps often rely on `<div>` containers instead of native `<form>` tags, which breaks the native "press Enter to submit" behavior. This forces keyboard-only or screen-reader users to navigate all the way to the submit button, degrading accessibility and UX.
 **Action:** When working with form-like input containers in legacy applications, always bind a `keypress` event on the inputs to explicitly trigger the submission action when the Enter key (`e.which === 13`) is pressed.
+
+## 2026-04-11 - Guarding Against Race Conditions in Temporary Visual States
+**Learning:** When implementing temporary visual feedback states (like a 'Saved!' button that reverts after a timeout), failing to guard against multiple rapid clicks can cause race conditions where timers overlap, causing the button state to glitch or permanently stick in the wrong state.
+**Action:** Always use a state flag (e.g. `$el.data('saving')`) or disable the element to ignore interactions while the temporary state is active, resetting it only when the timeout completes.

--- a/public/jutty.js
+++ b/public/jutty.js
@@ -204,11 +204,22 @@ $(document).ready(function () {
     }
 
     $save.click(function () {
+        if ($save.data('saving')) return;
+        $save.data('saving', true);
+
         var vals = getVals();
         savedConnections[vals.name] = vals;
         store.set('connections', savedConnections);
 
         listConnections();
+
+        var originalHtml = $save.html();
+        $save.html('<span class="glyphicon glyphicon-ok" aria-hidden="true"></span> Saved!').addClass('btn-success').removeClass('btn-primary');
+
+        setTimeout(function() {
+            $save.html(originalHtml).removeClass('btn-success').addClass('btn-primary');
+            $save.data('saving', false);
+        }, 1500);
     });
 
 

--- a/test-save-ux.js
+++ b/test-save-ux.js
@@ -1,0 +1,81 @@
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  page.on('console', msg => console.log('BROWSER CONSOLE:', msg.text()));
+
+  // Mock socket.io request
+  await page.route('**/socket.io.js', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: 'window.io = function() { return { on: function(){}, emit: function(){} }; };'
+  }));
+
+  // Inject mocks for window.store and window.hterm as advised by memory
+  await page.addInitScript(() => {
+    window.store = {
+      get: () => ({}),
+      set: () => { console.log('store.set called'); }
+    };
+    window.hterm = { defaultStorage: {}, Terminal: class { decorate() {} setCursorPosition() {} setCursorVisible() {} runCommandClass() {} } };
+    window.hterm.Terminal.prototype.prefs_ = { set: () => {} };
+    window.lib = {
+        Storage: { Local: class {} },
+        init: (cb) => { if (cb) cb(); }
+    };
+  });
+
+  await page.goto('file://' + process.cwd() + '/public/index.html');
+  await page.waitForTimeout(1000);
+
+  // Fill in connection details to enable save button
+  await page.fill('#host', '127.0.0.1');
+  await page.fill('#user', 'root');
+  await page.fill('#name', 'My Connection');
+
+  // Trigger keyup to ensure checkButtons runs
+  await page.evaluate(() => {
+    document.getElementById('name').dispatchEvent(new KeyboardEvent('keyup', {'key': 'a'}));
+    document.getElementById('host').dispatchEvent(new KeyboardEvent('keyup', {'key': 'a'}));
+  });
+
+  let isDisabled = await page.evaluate(() => document.getElementById('save').hasAttribute('disabled'));
+  console.log("Is disabled?", isDisabled);
+
+  // Verify initial state
+  let btnClass = await page.getAttribute('#save', 'class');
+  let btnText = await page.innerText('#save');
+  console.log("Initial state:", { class: btnClass, text: btnText.trim() });
+  if (!btnClass.includes('btn-primary')) throw new Error('Expected btn-primary');
+
+  // Click save
+  await page.evaluate(() => {
+    document.getElementById('save').click();
+  });
+
+  // Wait a small amount of time to allow DOM to update, but not enough for timeout
+  await page.waitForTimeout(100);
+
+  // Verify 'Saved!' state
+  btnClass = await page.getAttribute('#save', 'class');
+  btnText = await page.innerText('#save');
+  console.log("Saved state:", { class: btnClass, text: btnText.trim() });
+  if (!btnClass.includes('btn-success')) throw new Error('Expected btn-success');
+  if (!btnText.includes('Saved!')) throw new Error('Expected "Saved!" text');
+
+  // Wait for timeout to expire
+  await page.waitForTimeout(1600);
+
+  // Verify original state restored
+  btnClass = await page.getAttribute('#save', 'class');
+  btnText = await page.innerText('#save');
+  console.log("Restored state:", { class: btnClass, text: btnText.trim() });
+  if (!btnClass.includes('btn-primary')) throw new Error('Expected btn-primary restored');
+  if (btnText.includes('Saved!')) throw new Error('Did not expect "Saved!" text');
+
+  console.log("All assertions passed!");
+  await browser.close();
+})();


### PR DESCRIPTION
💡 **What:** Added a temporary "Saved!" visual feedback state to the `#save` connection button. The button turns green and displays "Saved!" along with a checkmark icon for 1.5 seconds after a successful click, before reverting back to its original state.
🎯 **Why:** Previously, there was no feedback when clicking the Save button other than the item silently appearing in the list on the right. For users on smaller screens where the list might be pushed out of immediate view, or just for general intuitive use, clicking a primary action should result in clear, immediate visual confirmation of success.
📸 **Before/After:** The button now visually toggles from `btn-primary` to `btn-success` temporarily, confirming the save action.
♿ **Accessibility:** N/A (Visual feedback only, though button state changes are generally good for cognitive accessibility by confirming actions). Race condition protection added via `$save.data('saving')` to prevent the UI from glitching if clicked rapidly multiple times.

---
*PR created automatically by Jules for task [1261754867014310935](https://jules.google.com/task/1261754867014310935) started by @mbarbine*