### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability on socket connect

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Command/Argument Injection via unsanitized `data.host` and `data.port` parameters in `socket.on('start')` which were directly passed to `pty.spawn`. An attacker could inject arguments starting with `-` like `-oProxyCommand`.
 **Learning:** Even though `pty.spawn` doesn't execute a shell directly, passing completely arbitrary arguments starting with hyphens can invoke dangerous features of the underlying program (e.g. telnet).
 **Prevention:** Always sanitize and validate socket inputs using strict regex (e.g., ensuring hostnames start with alphanumeric characters `^[a-zA-Z0-9]`) and explicitly parsing/bounding numbers before passing them to OS-level spawn commands.
+
+## 2026-04-17 - [Unhandled Promise/Undefined crash in Socket.io connection]
+**Vulnerability:** Unauthenticated Denial of Service (DoS).
+**Learning:** If event listeners and properties of a scoped variable (e.g., `term.pid` and `term.on('data')`) are accessed directly inside a `connection` event loop *before* that variable is safely initialized via an explicit client command (e.g., `start`), a client can crash the server merely by opening a connection. The event loop expects `term` to exist immediately.
+**Prevention:** Always wrap listeners or initializations that depend on dynamically spawned external processes in null checks (`if (term) { ... }`) to gracefully fail or avoid dereferencing `undefined` when the object is uninitialized.

--- a/app.js
+++ b/app.js
@@ -91,16 +91,18 @@ function setupSocketIo(httpserv) {
             });
         });
 
-        log.info(term.pid, 'spawned');
-        term.on('data', function(data) {
-            socket.emit('output', data);
-        });
-        term.on('exit', function (code) {
-            log.info(term.pid, 'ended');
-            socket.emit('end');
-            term.kill();
-            term = null;
-        });
+        if (term) {
+            log.info(term.pid, 'spawned');
+            term.on('data', function(data) {
+                socket.emit('output', data);
+            });
+            term.on('exit', function (code) {
+                log.info(term.pid, 'ended');
+                socket.emit('end');
+                term.kill();
+                term = null;
+            });
+        }
 
         socket.on('resize', function (data) {
             term && term.resize(parseInt(data.col, 10) || 80, parseInt(data.row, 10) || 24);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability on socket connect

🚨 Severity: CRITICAL
💡 Vulnerability: Unauthenticated DoS crash where accessing `term.pid` on connection threw an undefined error because `term` was initialized only upon the client sending a `start` event.
🎯 Impact: Anyone could crash the server simply by opening a websocket connection.
🔧 Fix: Wrapped the potentially uninitialized `term` references within an `if (term) { ... }` null check at the connection scope.
✅ Verification: Start server, open raw websocket connection without sending 'start', and observe server remains active instead of crashing.

---
*PR created automatically by Jules for task [14502055373452262293](https://jules.google.com/task/14502055373452262293) started by @mbarbine*