### PR TITLE
🛡️ Sentinel: Refactor connection list to use programmatic element creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Double event listener registration for `term.on('data')` and `term.on('exit')` that was located outside `socket.on('start')`, combined with `safeHost` allowing leading hyphens, which could allow bypassing the regex check and injecting options to the telnet command spawned via `node-pty`.
 **Learning:** `term` is declared outside of `socket.on('start')` but double registered outside of it while `term.pid` accessing caused crashes. By only having the listener inside `start`, and also ensuring `safeHost` doesn't begin with a hyphen.
 **Prevention:** Remove duplicated code outside closures that depends on variables defined inside them, and add explicit prefix checks for arguments passed to `node-pty`.
+
+## 2024-05-24 - [DOM-based XSS in jQuery HTML concatenation]
+**Vulnerability:** DOM-based Cross-Site Scripting (XSS) via jQuery `html()` manipulation in `public/jutty.js`. The `listConnections` function iterates over user-controlled connection names and builds raw HTML strings containing those names (`'<a ... data-target="' + name + '">' + name + ...`). If a user creates a connection with a malicious name (like `<script>alert(1)</script>`), the script is executed when the connection list is rendered.
+**Learning:** Concatenating user inputs directly into HTML strings and assigning them via `.html()`, `.append()`, or similar DOM injection points easily causes DOM-based XSS, even for seemingly innocuous "names".
+**Prevention:** Avoid constructing HTML markup with user inputs using string concatenation. Instead, use jQuery's programmatic element creation (e.g., `$('<a>', { text: name, class: '...' })`), which safely escapes text content and attributes automatically.

--- a/public/jutty.js
+++ b/public/jutty.js
@@ -157,21 +157,36 @@ $(document).ready(function () {
 
     function listConnections() {
         var names = Object.keys(savedConnections).sort();
-        var html = '';
+        $connections.empty();
+
         if (names.length === 0) {
-            html = '<div class="list-group-item text-muted text-center p-3">' +
+            var html = '<div class="list-group-item text-muted text-center p-3">' +
                    '<span class="glyphicon glyphicon-info-sign h2 d-block mb-3" aria-hidden="true"></span><br>' +
                    'No saved connections yet.<br>Fill out the form and click "Save" to add one.' +
                    '</div>';
+            $connections.html(html);
         } else {
             names.forEach(function (name) {
-                html += '<a class="list-group-item load" href="#" data-target="' + name + '">' + name +
-                    '<button class="btn btn-xs btn-danger delete" data-name="' + name + '" aria-label="Delete ' + name + ' connection" title="Delete ' + name + ' connection">' +
-                    '<span class="glyphicon glyphicon-trash" aria-hidden="true"></span>' +
-                    '</button></a>';
+                var $a = $('<a>', {
+                    class: 'list-group-item load',
+                    href: '#',
+                    'data-target': name,
+                    text: name
+                });
+                var $btn = $('<button>', {
+                    class: 'btn btn-xs btn-danger delete',
+                    'data-name': name,
+                    'aria-label': 'Delete ' + name + ' connection',
+                    title: 'Delete ' + name + ' connection'
+                });
+                $btn.append($('<span>', {
+                    class: 'glyphicon glyphicon-trash',
+                    'aria-hidden': 'true'
+                }));
+                $a.append($btn);
+                $connections.append($a);
             });
         }
-        $connections.html(html);
     }
 
     // ⚡ Bolt Optimization: Use event delegation on parent instead of binding to individual elements


### PR DESCRIPTION
🛡️ Sentinel: Refactor connection list to use programmatic element creation

**Severity:** HIGH
**Context:**
The connection list previously used string concatenation to construct HTML for saved connection entries in `public/jutty.js`. This approach is risky when incorporating dynamic data as it bypasses proper encoding.

**Fix:**
Replaced the string concatenation logic in `listConnections` with jQuery's programmatic element creation (e.g., `$('<a>', { ... })`). This automatically escapes text and attributes, significantly hardening the application against DOM manipulation risks.

**Verification:**
- Ran `pnpm exec mocha "test/**/*.test.js" --exit` and all tests passed.
- Verified JS syntax using `node -c public/jutty.js`.
- Confirmed the `.jules/sentinel.md` journal update accurately reflects this learning.

---
*PR created automatically by Jules for task [14873357449178926918](https://jules.google.com/task/14873357449178926918) started by @mbarbine*