### PR TITLE
🎨 Palette: Add screen reader support for async button states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2025-04-17 - Visual Feedback on Save Button
 **Learning:** Adding temporary visual feedback (like changing a "Save" button to "Saved!" with a checkmark) greatly improves user confidence, but doing so naively can cause race conditions if the user double-clicks, leading to broken UI states or duplicate saves.
 **Action:** Always guard temporary UI states with a flag (e.g., `$el.data('saving')` or `isSaving` state) and ignore subsequent actions until the timeout completes and the state is reset.
+
+## 2025-04-17 - Screen Reader Support for Async Buttons
+**Learning:** When buttons update their text dynamically to show loading or success states (like "Connecting..." or "Saved!"), screen readers will not announce the state change by default, leaving non-visual users unaware of the action's progress.
+**Action:** Always add `aria-live="polite"` to buttons that have text that changes asynchronously. This ensures that when the inner text changes (e.g. from "Connect" to "Connecting..."), the screen reader will naturally announce the new state to the user.

--- a/public/index.html
+++ b/public/index.html
@@ -135,7 +135,7 @@
 -->
                         <div class="row">
                             <div class="col-lg-3 col-md-3 col-xs-3">
-                                <button class="btn btn-primary" id="start">
+                                <button class="btn btn-primary" id="start" aria-live="polite">
                                     <span class="glyphicon glyphicon-console" aria-hidden="true"></span> Connect
                                 </button>
                             </div>
@@ -145,7 +145,7 @@
                                     <label class="input-group-addon" for="name" id="addon-name">Save as...</label>
                                     <input id="name" type="text" class="form-control" aria-describedby="addon-name" placeholder="Connection name">
                                     <span class="input-group-btn">
-                    <button class="btn btn-primary" type="button" id="save">
+                    <button class="btn btn-primary" type="button" id="save" aria-live="polite">
                         <span class="glyphicon glyphicon-save-file" aria-hidden="true"></span> Save
                     </button>
                   </span>


### PR DESCRIPTION
🎨 Palette: Add screen reader support for async button states

💡 What: Added `aria-live="polite"` to the "Connect" and "Save" buttons in `public/index.html`.
🎯 Why: These buttons update their text asynchronously (e.g., to "Connecting..." or "Saved!") when clicked. Without `aria-live`, screen readers do not announce these dynamic state changes, leaving non-visual users unaware of the action's progress.
📸 Before/After: Visuals remain unchanged; purely an accessibility fix.
♿ Accessibility: Ensures critical async button state changes are announced by screen readers.

---
*PR created automatically by Jules for task [8035048492336284384](https://jules.google.com/task/8035048492336284384) started by @mbarbine*