### PR TITLE
🎨 Palette: Add screen reader support to dynamic buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2025-04-17 - Visual Feedback on Save Button
 **Learning:** Adding temporary visual feedback (like changing a "Save" button to "Saved!" with a checkmark) greatly improves user confidence, but doing so naively can cause race conditions if the user double-clicks, leading to broken UI states or duplicate saves.
 **Action:** Always guard temporary UI states with a flag (e.g., `$el.data('saving')` or `isSaving` state) and ignore subsequent actions until the timeout completes and the state is reset.
+
+## 2025-04-17 - Screen Reader Support for Dynamically Updating Buttons
+**Learning:** Buttons that temporarily change text (e.g., from "Connect" to "Connecting..." or "Save" to "Saved!") do not announce these changes to screen readers by default. This leaves visually impaired users unaware of async operations or success feedback.
+**Action:** Always add `aria-live="polite"` to buttons that will have their inner text dynamically updated via JavaScript. This ensures that screen readers will announce the state changes.

--- a/public/index.html
+++ b/public/index.html
@@ -135,7 +135,7 @@
 -->
                         <div class="row">
                             <div class="col-lg-3 col-md-3 col-xs-3">
-                                <button class="btn btn-primary" id="start">
+                                <button class="btn btn-primary" id="start" aria-live="polite">
                                     <span class="glyphicon glyphicon-console" aria-hidden="true"></span> Connect
                                 </button>
                             </div>
@@ -145,7 +145,7 @@
                                     <label class="input-group-addon" for="name" id="addon-name">Save as...</label>
                                     <input id="name" type="text" class="form-control" aria-describedby="addon-name" placeholder="Connection name">
                                     <span class="input-group-btn">
-                    <button class="btn btn-primary" type="button" id="save">
+                    <button class="btn btn-primary" type="button" id="save" aria-live="polite">
                         <span class="glyphicon glyphicon-save-file" aria-hidden="true"></span> Save
                     </button>
                   </span>


### PR DESCRIPTION
💡 **What**: Added `aria-live="polite"` to the "Connect" (`#start`) and "Save" (`#save`) buttons in `public/index.html`.
🎯 **Why**: When a user clicks these buttons, the text dynamically updates (e.g., "Connecting..." and "Saved!") to provide visual feedback for async operations. However, without `aria-live`, screen readers remain silent about these changes, leaving visually impaired users unaware of the successful interaction or current loading state.
♿ **Accessibility**: Improves accessibility for screen reader users by ensuring dynamic button text changes are properly announced.
📸 **Before/After**: Visually identical, but significantly improves the experience for users relying on assistive technologies.

---
*PR created automatically by Jules for task [16982558212870395818](https://jules.google.com/task/16982558212870395818) started by @mbarbine*