### PR TITLE
🎨 Palette: Add `aria-live` to dynamic buttons for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,6 @@
 ## 2025-04-17 - Visual Feedback on Save Button
 **Learning:** Adding temporary visual feedback (like changing a "Save" button to "Saved!" with a checkmark) greatly improves user confidence, but doing so naively can cause race conditions if the user double-clicks, leading to broken UI states or duplicate saves.
 **Action:** Always guard temporary UI states with a flag (e.g., `$el.data('saving')` or `isSaving` state) and ignore subsequent actions until the timeout completes and the state is reset.
+## 2024-05-24 - Dynamic button text accessibility
+**Learning:** When using JavaScript to temporarily change button text (e.g. from "Save" to "Saved!" or "Connect" to "Connecting..."), screen readers often miss the update, leaving visually impaired users unaware of the action's success or loading state.
+**Action:** Always add `aria-live="polite"` to buttons or containers whose text content updates dynamically so that screen readers will announce the state changes asynchronously without interrupting the user.

--- a/public/index.html
+++ b/public/index.html
@@ -135,7 +135,7 @@
 -->
                         <div class="row">
                             <div class="col-lg-3 col-md-3 col-xs-3">
-                                <button class="btn btn-primary" id="start">
+                                <button class="btn btn-primary" id="start" aria-live="polite">
                                     <span class="glyphicon glyphicon-console" aria-hidden="true"></span> Connect
                                 </button>
                             </div>
@@ -145,7 +145,7 @@
                                     <label class="input-group-addon" for="name" id="addon-name">Save as...</label>
                                     <input id="name" type="text" class="form-control" aria-describedby="addon-name" placeholder="Connection name">
                                     <span class="input-group-btn">
-                    <button class="btn btn-primary" type="button" id="save">
+                    <button class="btn btn-primary" type="button" id="save" aria-live="polite">
                         <span class="glyphicon glyphicon-save-file" aria-hidden="true"></span> Save
                     </button>
                   </span>


### PR DESCRIPTION
💡 **What:** Added the `aria-live="polite"` attribute to the `#start` ("Connect") and `#save` ("Save") buttons in `public/index.html`. Also added a journal entry to `.Jules/palette.md` to document the learning.

🎯 **Why:** Both buttons have their text content modified dynamically by `jutty.js` (e.g., to "Connecting..." and "Saved!"). Without `aria-live="polite"`, screen readers do not announce these state changes, leaving visually impaired users unaware of the successful action or loading state.

📸 **Before/After:** No visual layout changes. ARIA attributes are functionally invisible to sighted users. (Screenshot and video recorded during verification).

♿ **Accessibility:** Screen readers will now asynchronously announce when the connection button enters the "Connecting..." state and when the save button enters the "Saved!" state without interrupting the user.

---
*PR created automatically by Jules for task [12774966856592042990](https://jules.google.com/task/12774966856592042990) started by @mbarbine*